### PR TITLE
responder: modify to accept multiple analyses in the response

### DIFF
--- a/responder/curl.sh
+++ b/responder/curl.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+curl -X POST \
+     -d'@test-data.json' \
+     -H'Content-Type:application/json' \
+     -H'ce-specversion:1.0' \
+     -H'ce-type:faces.api.response' \
+     -H'ce-source:/processor' \
+     -H'ce-id:45c83279-c8a1-4db6-a703-b3768db93887' \
+     -H'ce-time:2019-11-06T11:17:00Z' \
+     http://localhost:8080/
+

--- a/responder/index.js
+++ b/responder/index.js
@@ -22,13 +22,32 @@ async function sendReply(context, response) {
     
     // send chat response async
     axios.post(url, {
-      chat_id: response.chat,
-      text: `Hi! Thanks for playing. ;) This person looks to be about ${response.age} and ${response.emotion}`
+      chat_id: response[0].chat,
+      text: formatResponse(response)
     })
-    .then(_ => console.log('Done'))
-    .catch(err => console.error(err));
-  })
+    .then(_ => context.log.info('Done'))
+    .catch(err => context.log.error(err));
+  });
 
 };
+
+function formatResponse(response) {
+  let faces = response.length === 1 ? 'face' : 'faces';
+  let text = `Hi! Thanks for playing. :)
+I found ${response.length} ${faces} in this image.
+`;
+
+  response.forEach(image => {
+    text += `
+
+* Age: ${image.age}`;
+
+    for(const emotion in image.emotion) {
+      text += `
+  - ${emotion}: ${image.emotion[emotion]}`;
+    }
+  });
+  return text;
+}
 
 module.exports = sendReply;

--- a/responder/test-data.json
+++ b/responder/test-data.json
@@ -1,0 +1,1 @@
+[{"chat":527645760,"age":56.0,"emotion":{"anger":0.006,"contempt":0.019,"disgust":0.077,"fear":0.003,"happiness":0.007,"neutral":0.247,"sadness":0.639,"surprise":0.001}},{"chat":527645760,"age":38.0,"emotion":{"anger":0.0,"contempt":0.002,"disgust":0.0,"fear":0.0,"happiness":0.054,"neutral":0.943,"sadness":0.0,"surprise":0.0}}]


### PR DESCRIPTION
@matejvasek I've modified the responder to work with how you have changed Quarkus on this branch. When receiving data like this in a CloudEvent

```
[{"chat":527645760,"age":56.0,"emotion":{"anger":0.006,"contempt":0.019,"disgust":0.077,"fear":0.003,"happiness":0.007,"neutral":0.247,"sadness":0.639,"surprise":0.001}},{"chat":527645760,"age":38.0,"emotion":{"anger":0.0,"contempt":0.002,"disgust":0.0,"fear":0.0,"happiness":0.054,"neutral":0.943,"sadness":0.0,"surprise":0.0}}]
```

It responds to the Telegram chat with a message like this

```
Hi! Thanks for playing. :)
I found 2 faces in this image.
* Age: 56
  - anger: 0.006
  - contempt: 0.019
  - disgust: 0.077
  - fear: 0.003
  - happiness: 0.007
  - neutral: 0.247
  - sadness: 0.639
  - surprise: 0.001
* Age: 38
  - anger: 0
  - contempt: 0.002
  - disgust: 0
  - fear: 0
  - happiness: 0.054
  - neutral: 0.943
  - sadness: 0
  - surprise: 0
```

You can test it out by running the function with `npm run local`, and then in another terminal running `curl.sh`. If we have time, I would actually like to change the `Output` to have a `chat` property instead of having it repeated over and over in the array. It would also be nice to have the URL, so I could respond with the picture (in case there are multiple people chatting with the bot at once).


Signed-off-by: Lance Ball <lball@redhat.com>