### PR TITLE
feat: add image:text event type as possible event from receiver

### DIFF
--- a/deploy/broker.yaml
+++ b/deploy/broker.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: eventing.knative.dev/v1
-kind: broker
+kind: Broker
 metadata:
  name: default
 

--- a/deploy/trigger-processor.yaml
+++ b/deploy/trigger-processor.yaml
@@ -7,7 +7,7 @@ spec:
   broker: default
   filter:
     attributes:
-      type: image:received
+      type: telegram:image
   subscriber:
     ref:
      apiVersion: serving.knative.dev/v1

--- a/deploy/trigger-responder.yaml
+++ b/deploy/trigger-responder.yaml
@@ -6,8 +6,11 @@ metadata:
 spec:
   broker: default
   filter:
-    attributes:
-      type: telegram.photo.processed
+    and:
+    - attributes:
+        type: telegram:image:processed
+    - attributes:
+      type: telegram:text
   subscriber:
     ref:
      apiVersion: serving.knative.dev/v1

--- a/processor/src/main/java/functions/Function.java
+++ b/processor/src/main/java/functions/Function.java
@@ -38,7 +38,7 @@ public class Function {
     String apiKey;
 
     @Funq
-    @CloudEventMapping(responseType = "telegram.photo.processed")
+    @CloudEventMapping(responseType = "telegram:image:processed")
     public Uni<Output[]> function(Input input, @Context CloudEvent cloudEvent) {
         return Uni.createFrom().emitter(emitter -> {
             getData(input, cloudEvent, emitter, 100);

--- a/processor/src/test/java/functions/FunctionTest.java
+++ b/processor/src/test/java/functions/FunctionTest.java
@@ -29,7 +29,7 @@ public class FunctionTest {
                 .header("ce-id", notNullValue())
                 .header("ce-specversion", equalTo("1.0"))
                 .header("ce-source", equalTo("function"))
-                .header("ce-type", equalTo("telegram.photo.processed"))
+                .header("ce-type", equalTo("telegram:image:processed"))
                 .body("message", equalTo("Hello!"));
     }
 

--- a/resources/camelk-telegram-event.json
+++ b/resources/camelk-telegram-event.json
@@ -1,0 +1,52 @@
+ {
+  "date": 1605648466,
+  "from": {
+    "id": 527645760,
+    "username": "lanceball",
+    "bot": false,
+    "first_name": "Lance",
+    "last_name": "Ball",
+    "is_bot": false
+  },
+  "text": "Here is a photo",
+  "chat": {
+    "id": "527645760",
+    "title": null,
+    "type": "private",
+    "all_members_are_administrators": false
+  },
+  "photo": [
+    {
+      "width": 240,
+      "height": 320,
+      "file_id": "AgACAgEAAxkBAAMuX7RAUgnadfeDcNg1I8WwrlOlMc8AAqaoMRuNsqFFveeQ7VrJu4_u324GAAQBAAMCAANtAANOyAUAAR4E",
+      "file_unique_id": "AQAD7t9uBgAETsgFAAE",
+      "file_size": 26294
+    },
+    {
+      "width": 599,
+      "height": 800,
+      "file_id": "AgACAgEAAxkBAAMuX7RAUgnadfeDcNg1I8WwrlOlMc8AAqaoMRuNsqFFveeQ7VrJu4_u324GAAQBAAMCAAN4AANPyAUAAR4E",
+      "file_unique_id": "AQAD7t9uBgAET8gFAAE",
+      "file_size": 115368
+    },
+    {
+      "width": 956,
+      "height": 1276,
+      "file_id": "AgACAgEAAxkBAAMuX7RAUgnadfeDcNg1I8WwrlOlMc8AAqaoMRuNsqFFveeQ7VrJu4_u324GAAQBAAMCAAN5AANMyAUAAR4E",
+      "file_unique_id": "AQAD7t9uBgAETMgFAAE",
+      "file_size": 198902
+    }
+  ],
+  "video": null,
+  "audio": null,
+  "document": null,
+  "sticker": null,
+  "entities": null,
+  "caption": null,
+  "game": null,
+  "message_id": 46,
+  "location": null,
+  "caption_entities": null,
+  "reply_markup": null
+}

--- a/responder/index.js
+++ b/responder/index.js
@@ -14,31 +14,47 @@ if (!token) {
 // Make this function async so we can return immediately
 // to the invoker, while doing the work of replying to
 // the original chat message.
-async function sendReply(context, response) {
+async function sendReply(context, data) {
   if (!context.cloudevent) {
+    context.log.error('No CloudEvent received');
     return {
-      message: 'No cloud event received'
+      message: 'No CloudEvent received'
     };
   }
 
   return new Promise((resolve, reject) => {
     // resolve immediately with HTTP 204 No Content
     resolve({ code: 204 });
+
+    let chatId;
+    const eventType = context.cloudevent.type;
+
+    let response;
+    if (eventType === 'telegram:image:processed') {
+      response = formatResponse(data);
+      chatId = data[0].chat;
+    } else if (eventType === 'telegram:text') {
+      response = `👋 😃
+Send me an image with faces in it and I will analyze it for you.`;
+      chatId = data.chat;
+    } else {
+      // Don't know how to handle any other kind of event
+      context.log.error(`Cannot handle events of type: ${eventType}`);
+    }
     
     // send chat response async
     axios.post(url, {
-      chat_id: response[0].chat,
-      text: formatResponse(response)
+      chat_id: chatId,
+      text: response
     })
     .then(_ => context.log.info('Done'))
     .catch(err => context.log.error(err));
   });
-
-};
+}
 
 function formatResponse(response) {
   let faces = response.length === 1 ? 'face' : 'faces';
-  let text = `Hi! Thanks for playing. :)
+  let text = `Hi! Thanks for playing. 😃
 I found ${response.length} ${faces} in this image.
 `;
 


### PR DESCRIPTION
This allows `responder` to listen both for image processed events as well as simple text events. If the bot receives a message that is just plain text, the `responder` should provide some brief instructions.

I also made a few formatting changes to `handle.go` because my IDE was complaining a lot.

~~I have not tested on a cluster yet. Marking as WIP until I can.~~

~~/me waits for a cluster to spin up~~

Signed-off-by: Lance Ball <lball@redhat.com>