### PR TITLE
chore: use consistent CE type values

### DIFF
--- a/deploy/trigger-processor.yaml
+++ b/deploy/trigger-processor.yaml
@@ -7,7 +7,7 @@ spec:
   broker: default
   filter:
     attributes:
-      type: telegram:image
+      type: telegram.image
   subscriber:
     ref:
      apiVersion: serving.knative.dev/v1

--- a/deploy/trigger-responder.yaml
+++ b/deploy/trigger-responder.yaml
@@ -8,9 +8,9 @@ spec:
   filter:
     and:
     - attributes:
-        type: telegram:image:processed
+        type: telegram.image.processed
     - attributes:
-      type: telegram:text
+      type: telegram.text
   subscriber:
     ref:
      apiVersion: serving.knative.dev/v1

--- a/processor/src/main/java/functions/Function.java
+++ b/processor/src/main/java/functions/Function.java
@@ -38,7 +38,7 @@ public class Function {
     String apiKey;
 
     @Funq
-    @CloudEventMapping(responseType = "telegram:image:processed")
+    @CloudEventMapping(responseType = "telegram.image.processed")
     public Uni<Output[]> function(Input input, @Context CloudEvent cloudEvent) {
         return Uni.createFrom().emitter(emitter -> {
             getData(input, cloudEvent, emitter, 100);

--- a/processor/src/test/java/functions/FunctionTest.java
+++ b/processor/src/test/java/functions/FunctionTest.java
@@ -29,7 +29,7 @@ public class FunctionTest {
                 .header("ce-id", notNullValue())
                 .header("ce-specversion", equalTo("1.0"))
                 .header("ce-source", equalTo("function"))
-                .header("ce-type", equalTo("telegram:image:processed"))
+                .header("ce-type", equalTo("telegram.image.processed"))
                 .body("message", equalTo("Hello!"));
     }
 

--- a/receiver/handle.go
+++ b/receiver/handle.go
@@ -71,7 +71,7 @@ func Handle(ctx context.Context, event cloudevents.Event) (resp *cloudevents.Eve
 		response := cloudevents.NewEvent()
 		response.SetID(event.ID())
 		response.SetSource("function:receiver")
-		response.SetType("telegram:text")
+		response.SetType("telegram.text")
 		response.SetData(cloudevents.ApplicationJSON, Response{
 			Chat: chatID,
 			Text: msg.Text,
@@ -104,7 +104,7 @@ func Handle(ctx context.Context, event cloudevents.Event) (resp *cloudevents.Eve
 	response := cloudevents.NewEvent()
 	response.SetID(event.ID())
 	response.SetSource("function:receiver")
-	response.SetType("telegram:image")
+	response.SetType("telegram.image")
 	response.SetData(cloudevents.ApplicationJSON, Response{
 		Chat: chatID,
 		URL:  donwloadPhotoBaseUrl + photoPath,

--- a/responder/index.js
+++ b/responder/index.js
@@ -30,10 +30,10 @@ async function sendReply(context, data) {
     const eventType = context.cloudevent.type;
 
     let response;
-    if (eventType === 'telegram:image:processed') {
+    if (eventType === 'telegram.image.processed') {
       response = formatResponse(data);
       chatId = data[0].chat;
-    } else if (eventType === 'telegram:text') {
+    } else if (eventType === 'telegram.text') {
       response = `👋 😃
 Send me an image with faces in it and I will analyze it for you.`;
       chatId = data.chat;


### PR DESCRIPTION
UPDATED: Let's use `.` in the CE type values

Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>