### PR TITLE
fix: correct yaml formatting

### DIFF
--- a/deploy/trigger-responder.yaml
+++ b/deploy/trigger-responder.yaml
@@ -8,7 +8,7 @@ spec:
   filter:
     and:
     - attributes:
-        type: telegram.image.processed
+      type: telegram.image.processed
     - attributes:
       type: telegram.text
   subscriber:


### PR DESCRIPTION
trigger-responder.yaml is not formatted correctly, which results in non functioning trigger & filter.

Signed-off-by: Zbynek Roubalik <zroubali@redhat.com>